### PR TITLE
Adds a Redis Cluster with HA and auto-bootstrap

### DIFF
--- a/manifests/redis-bootstrap.yaml
+++ b/manifests/redis-bootstrap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis
+    redis-sentinel: "true"
+  name: redis-bootstrap
+  namespace: dojot
+spec:
+  containers:
+    - name: redis
+      image: kubernetes/redis:v1
+      env:
+        - name: MASTER
+          value: "true"
+      ports:
+        - containerPort: 6379
+      resources:
+        limits:
+          cpu: "0.1"
+    - name: redis-sentinel
+      image: kubernetes/redis:v1
+      env:
+        - name: SENTINEL
+          value: "true"
+      ports:
+        - containerPort: 26379

--- a/manifests/redis-cluster.yaml
+++ b/manifests/redis-cluster.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    name: redis
+  name: redis
+  namespace: dojot
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        name: redis
+    spec:
+      containers:
+      - name: redis
+        image: kubernetes/redis:v1
+        ports:
+        - containerPort: 6379

--- a/manifests/redis-sentinel-cluster.yaml
+++ b/manifests/redis-sentinel-cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redis-sentinel
+  namespace: dojot
+spec:
+  replicas: 3
+  selector:
+    redis-sentinel: "true"
+  template:
+    metadata:
+      labels:
+        name: redis-sentinel
+        redis-sentinel: "true"
+    spec:
+      containers:
+      - name: redis-sentinel
+        image: kubernetes/redis:v1
+        env:
+          - name: SENTINEL
+            value: "true"
+        ports:
+          - containerPort: 26379

--- a/manifests/redis-sentinel-service.yaml
+++ b/manifests/redis-sentinel-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: redis-sentinel
+  name: redis-sentinel
+  namespace: dojot
+spec:
+  ports:
+    - port: 26379
+      targetPort: 26379
+  selector:
+    redis-sentinel: "true"


### PR DESCRIPTION
Adds a redis cluster composed by N nodes:
 1 master, N-1 slaves

There is also a redis-sentinel cluster for monitoring the status of the redis cluster.

The cluster is bootstrapped by the pod redis-bootstrap

resolves dojot/dojot#97