### PR TITLE
Adds MongoDB sharding capability

### DIFF
--- a/manifests/history.yaml
+++ b/manifests/history.yaml
@@ -56,10 +56,10 @@ spec:
       - image: dojot/persister:latest
         name: persister
         env:
-        - name: MONGO_SHARD
-          value: "true"
         - name: FALCON_SETTINGS_MODULE
           value: history.settings.docker
-        - name: KAFKA_ADDRESS
-          value: kafka-server
+        - name: MONGO_REPLICA_SET
+          value: rs0
+        - name: KAFKA_HOST
+          value: kafka-server:9092
       restartPolicy: Always

--- a/manifests/history.yaml
+++ b/manifests/history.yaml
@@ -56,10 +56,10 @@ spec:
       - image: dojot/persister:latest
         name: persister
         env:
+        - name: MONGO_SHARD
+          value: "true"
         - name: FALCON_SETTINGS_MODULE
           value: history.settings.docker
-        - name: MONGO_REPLICA_SET
-          value: rs0
-        - name: KAFKA_HOST
-          value: kafka-server:9092
+        - name: KAFKA_ADDRESS
+          value: kafka-server
       restartPolicy: Always

--- a/manifests/mongodb_shard/history.yaml
+++ b/manifests/mongodb_shard/history.yaml
@@ -58,8 +58,8 @@ spec:
         env:
         - name: FALCON_SETTINGS_MODULE
           value: history.settings.docker
-        - name: MONGO_REPLICA_SET
-          value: rs0
-        - name: KAFKA_HOST
-          value: kafka-server:9092
+        - name: KAFKA_ADDRESS
+          value: kafka-server
+        - name: MONGO_SHARD
+          value: "true"
       restartPolicy: Always

--- a/manifests/mongodb_shard/history.yaml
+++ b/manifests/mongodb_shard/history.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: history
+  name: history
+  namespace: dojot
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    name: history
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    name: history
+  name: history
+  namespace: dojot
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: history
+    spec:
+      containers:
+      - image: dojot/history:latest
+        name: history
+        env:
+        - name: FALCON_SETTINGS_MODULE
+          value: history.settings.docker
+        - name: MONGO_REPLICA_SET
+          value: rs0
+        - name: KAFKA_HOST
+          value: kafka-server:9092
+      restartPolicy: Always
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    name: persister
+  name: persister
+  namespace: dojot
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: persister
+    spec:
+      containers:
+      - image: dojot/persister:latest
+        name: persister
+        env:
+        - name: FALCON_SETTINGS_MODULE
+          value: history.settings.docker
+        - name: MONGO_REPLICA_SET
+          value: rs0
+        - name: KAFKA_HOST
+          value: kafka-server:9092
+      restartPolicy: Always

--- a/manifests/mongodb_shard/kill_pods.sh
+++ b/manifests/mongodb_shard/kill_pods.sh
@@ -1,0 +1,17 @@
+re='^[0-9]+$'
+if [ "$1" == "" ]; then
+    export N_SHARDS=3
+elif ! [[ $1 =~ $re ]]; then
+    echo "insert a valid integer"
+    exit 1
+else
+    export N_SHARDS=$1
+fi
+
+kubectl delete -f mongos.yaml
+kubectl delete -f mongocfg.yaml
+
+for ((i=0;i<N_SHARDS;i++)); do
+    kubectl delete -f mongosh$i.yaml
+    rm mongosh$i.yaml
+done

--- a/manifests/mongodb_shard/mongocfg.yaml
+++ b/manifests/mongodb_shard/mongocfg.yaml
@@ -1,0 +1,100 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: mongocfg
+  namespace: dojot
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mongocfg-role
+  namespace: dojot
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mongocfg-role-binding
+  namespace: dojot
+subjects:
+- kind: ServiceAccount
+  name: mongocfg
+  namespace: dojot
+roleRef:
+  kind: Role
+  name: mongocfg-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongocfg
+  labels:
+    app: mongocfg
+  namespace: dojot
+spec:
+  clusterIP: None
+  ports:
+  - port: 27019
+    targetPort: 27019
+    name: mongocfg
+  selector:
+    app: mongocfg
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongocfg
+  namespace: dojot
+spec:
+  selector:
+    matchLabels:
+      app: mongocfg
+  serviceName: "mongocfg"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: mongocfg
+    spec:
+      terminationGracePeriodSeconds: 15
+      containers:
+      - name: mongocfg
+        image: mongo:4.0.0
+        command:
+        - mongod
+        - "--configsvr"
+        - "--replSet"
+        - configReplSet
+        - "--bind_ip"
+        - 0.0.0.0
+        ports:
+        - containerPort: 27019
+          name: mongocfg
+        # volumeMounts:
+        #   - name: mongo-volume
+        #     mountPath: /data/db
+      - name: mongo-sidecar
+        image: cvallance/mongo-k8s-sidecar
+        env:
+        - name: MONGO_SIDECAR_POD_LABELS
+          value: "app=mongocfg"
+        - name: KUBE_NAMESPACE
+          value: dojot
+        - name: CONFIG_SVR
+          value: 'true'
+        - name: MONGO_PORT
+          value: '27019'
+      serviceAccountName: mongocfg
+  # volumeClaimTemplates:
+  # - metadata:
+  #     name: mongo-volume
+  #   spec:
+  #     accessModes: [ "ReadWriteOnce" ]
+  #     storageClassName: dojot
+  #     resources:
+  #       requests:
+  #         storage: 1Gi

--- a/manifests/mongodb_shard/mongos.yaml
+++ b/manifests/mongodb_shard/mongos.yaml
@@ -1,0 +1,95 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: mongodb
+  namespace: dojot
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mongodb-role
+  namespace: dojot
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mongodb-role-binding
+  namespace: dojot
+subjects:
+- kind: ServiceAccount
+  name: mongodb
+  namespace: dojot
+roleRef:
+  kind: Role
+  name: mongodb-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+  namespace: dojot
+spec:
+  clusterIP: None
+  ports:
+  - port: 27017
+    targetPort: 27017
+    name: mongodb
+  selector:
+    app: mongodb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  namespace: dojot
+spec:
+  selector:
+    matchLabels:
+      app: mongodb
+  serviceName: "mongodb"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      terminationGracePeriodSeconds: 15
+      containers:
+      - name: mongodb
+        image: mongo:4.0.0
+        command:
+        - mongos
+        - "--configdb"
+        - configReplSet/192.168.139.139:27019,192.168.139.160:27019,192.168.139.172:27019
+        - "--bind_ip"
+        - 0.0.0.0
+        ports:
+        - containerPort: 27017
+          name: mongodb
+        # volumeMounts:
+        #   - name: mongo-volume
+        #     mountPath: /data/db
+      - name: mongo-sidecar
+        image: cvallance/mongo-k8s-sidecar
+        env:
+        - name: MONGO_SIDECAR_POD_LABELS
+          value: "app=mongodb"
+        - name: KUBE_NAMESPACE
+          value: dojot
+      serviceAccountName: mongodb
+  # volumeClaimTemplates:
+  # - metadata:
+  #     name: mongo-volume
+  #   spec:
+  #     accessModes: [ "ReadWriteOnce" ]
+  #     storageClassName: dojot
+  #     resources:
+  #       requests:
+  #         storage: 1Gi

--- a/manifests/mongodb_shard/mongosh.yaml
+++ b/manifests/mongodb_shard/mongosh.yaml
@@ -1,0 +1,100 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: mongosh0
+  namespace: dojot
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mongosh0-role
+  namespace: dojot
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mongosh0-role-binding
+  namespace: dojot
+subjects:
+- kind: ServiceAccount
+  name: mongosh0
+  namespace: dojot
+roleRef:
+  kind: Role
+  name: mongosh0-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongosh0
+  labels:
+    app: mongosh0
+  namespace: dojot
+spec:
+  clusterIP: None
+  ports:
+  - port: 27018
+    targetPort: 27018
+    name: mongosh0
+  selector:
+    app: mongosh0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongosh0
+  namespace: dojot
+spec:
+  selector:
+    matchLabels:
+      app: mongosh0
+  serviceName: "mongosh0"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: mongosh0
+    spec:
+      terminationGracePeriodSeconds: 15
+      containers:
+      - name: mongosh0
+        image: mongo:4.0.0
+        command:
+        - mongod
+        - "--replSet"
+        - rs0
+        - "--bind_ip"
+        - 0.0.0.0
+        - "--shardsvr"
+        - "--smallfiles"
+        - "--noprealloc"
+        ports:
+        - containerPort: 27018
+          name: mongosh0
+        # volumeMounts:
+        #   - name: mongo-volume
+        #     mountPath: /data/db
+      - name: mongo-sidecar
+        image: cvallance/mongo-k8s-sidecar
+        env:
+        - name: MONGO_SIDECAR_POD_LABELS
+          value: "app=mongosh0"
+        - name: KUBE_NAMESPACE
+          value: dojot
+        - name: MONGO_PORT
+          value: '27018'
+      serviceAccountName: mongosh0
+  # volumeClaimTemplates:
+  # - metadata:
+  #     name: mongo-volume
+  #   spec:
+  #     accessModes: [ "ReadWriteOnce" ]
+  #     storageClassName: dojot
+  #     resources:
+  #       requests:
+  #         storage: 1Gi

--- a/manifests/mongodb_shard/start_pods.sh
+++ b/manifests/mongodb_shard/start_pods.sh
@@ -1,0 +1,46 @@
+# checks if positional argument is an integer
+re='^[0-9]+$'
+if [ "$1" == "" ]; then
+    echo "defaulting to N_SHARDS=3"
+    export N_SHARDS=3
+elif ! [[ $1 =~ $re ]]; then
+    echo "insert a valid integer"
+    exit 1
+else
+    export N_SHARDS=$1
+fi
+
+echo "creating namespace"
+kubectl create namespace dojot
+
+# creates new yaml file for each shard
+echo "starting $N_SHARDS shard replicas"
+for ((i=0;i<N_SHARDS;i++)); do
+    cp mongosh.yaml mongosh$i.yaml
+    sed -i -e "s/mongosh./mongosh$i/g" mongosh$i.yaml
+    sed -i -e "s/- rs./- rs$i/g" mongosh$i.yaml
+    kubectl -n dojot apply -f mongosh$i.yaml
+done
+
+echo "starting config server replica"
+kubectl -n dojot apply -f mongocfg.yaml
+
+# needs to wait enough time for all pods to be running
+echo "waiting for initialization to finish"
+sleep 2m
+
+# applies config servers endpoints to mongos.yaml file
+echo "starting mongos"
+export CONFIG_ENDPOINTS=$(kubectl -n dojot get endpoints mongocfg | grep mongocfg | awk '{print $2}')
+sed -i '/configReplSet/c\        - configReplSet/'"$CONFIG_ENDPOINTS" mongos.yaml
+kubectl -n dojot apply -f mongos.yaml
+
+# needs to wait enough time for mongos pod to be running
+sleep 20
+
+# adds endpoints for each shard (replica set) to mongos
+echo "adding shards to mongos"
+for ((i=0;i<N_SHARDS;i++)); do
+    kubectl -n dojot exec mongodb-0 -c mongodb -- mongo --eval "sh.addShard('rs$i/$(kubectl -n dojot get endpoints mongosh$i | grep mongosh$i | awk '{print $2}')')"
+done
+


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

MongoDB Sharding capability.
Sharding uses three kinds of mongo servers:
1. Mongo shard servers
2. Mongo config servers
3. Mongos router

This PR enables sharding for kubernetes deployments, with no effect to docker-compose deployments. New yaml files are created and used, and they are configured and run by new scripts that defines the number of shards to use. Shards and config servers are being used with replica sets.

* **What is the current behavior?** (You can also link to an open issue here)
No sharding available.

* **What is the new behavior (if this is a feature change)?**
Enables sharding possibility.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

* **Other information**: